### PR TITLE
[WIP]デプロイの準備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+public/uploads/*

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 /config/master.key
 
 public/uploads/*
+config/secrets.yml

--- a/Gemfile
+++ b/Gemfile
@@ -58,5 +58,9 @@ group :test do
   gem 'chromedriver-helper'
 end
 
+group :production do
+  gem 'unicorn', '5.4.1'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    kgio (2.11.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -136,6 +137,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    raindrops (0.19.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -179,6 +181,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unicorn (5.4.1)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -211,6 +216,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicorn (= 5.4.1)
   web-console (>= 3.3.0)
 
 RUBY VERSION

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,9 +8,13 @@ Bundler.require(*Rails.groups)
 
 module FreemarketSample46b
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
-
+    config.generators do |g|
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
+    
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/unicorn.rb
+++ b/unicorn.rb
@@ -1,0 +1,42 @@
+app_path = File.expand_path('../../', __FILE__)
+
+worker_processes 1
+
+working_directory app_path
+pid "#{app_path}/tmp/pids/unicorn.pid"
+listen "#{app_path}/tmp/sockets/unicorn.sock"
+stderr_path "#{app_path}/log/unicorn.stderr.log"
+stdout_path "#{app_path}/log/unicorn.stdout.log"
+
+listen 3000
+timeout 60
+
+preload_app true
+GC.respond_to?(:copy_on_write_friendly=) && GC.copy_on_write_friendly = true
+
+check_client_connection false
+
+run_once = true
+
+before_fork do |server, worker|
+  defined?(ActiveRecord::Base) &&
+    ActiveRecord::Base.connection.disconnect!
+
+  if run_once
+    run_once = false # prevent from firing again
+  end
+
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if File.exist?(old_pid) && server.pid != old_pid
+    begin
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH => e
+      logger.error e
+    end
+  end
+end
+
+after_fork do |_server, _worker|
+  defined?(ActiveRecord::Base) && ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
# what
EC2のサーバへのデプロイ準備

# why
デプロイ設定ファイルの編集のため

# steps
1. EC2インスタンスの生成
2. Linuxサーバ構築
3. MySQLの設定
4. Railsを起動する
5. Nginx経由でRailsにアクセスする
6. Capistranoによるデプロイ作業の自動化
7. S3の導入
8. Basic認証導入


# 注意点
- 必ずブランチを切って開発を進めること
- 以下のカリキュラムを参考に、必ずBasic認証をかけてください
- [https://master.tech-camp.in/curriculums/2955](https://master.tech-camp.in/curriculums/2955)
- 第一回目のスプリントレビューまでに終えておくこと
- secrets.ymlをプッシュしないように.gitignoreに記述すること
- S3の導入方法を工夫すること
- ChatSpace開発時と同様に導入すると、デプロイ担当者以外の開発環境で画像がアップロードできなくなるため
- aws_access_key_id, aws_secret_access_keyなどの鍵情報をチームに共有はしてはいけない
- 開発環境ではローカルに保存されるように条件分岐すること
- 費用の発生を防ぎたい場合、新たにアカウントを取得するか、ChatSpaceのEC2ならびにS3の環境を解放しておく必要があります。費用が発生しても構わない場合は、ChatSpaceに並行してインスタンス等作成してください（発生する費用は毎月数百円〜数千円です）