### PR TITLE
user_detailテーブルのprefecture_idカラムに修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protected
   def configure_permitted_parameters
     added_attrs = [:nickname, :self_introduction, :point ]
-    devise_parameter_sanitizer.permit(:sign_up, keys: [user_detail_attributes: [:id, :family_name, :first_name, :family_name_kana, :first_name_kana, :date_of_birth, :phone_number, :postal_code, :prefecture, :city, :address, :building_name]])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [user_detail_attributes: [:id, :family_name, :first_name, :family_name_kana, :first_name_kana, :date_of_birth, :phone_number, :postal_code, :prefecture_id, :city, :address, :building_name]])
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
     devise_parameter_sanitizer.permit :account_update, keys: added_attrs
     devise_parameter_sanitizer.permit :sign_in, keys: added_attrs

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,6 +1,7 @@
 class Prefecture < ActiveHash::Base
   include ActiveHash::Associations
   has_many :products
+  has_many :user_details
 
   self.data = [
       {id: 1, name: '北海道'}, 

--- a/app/models/user_detail.rb
+++ b/app/models/user_detail.rb
@@ -1,3 +1,6 @@
 class UserDetail < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+
   belongs_to :user
+  belongs_to_active_hash :prefecture, class_name: "Prefecture", foreign_key: "prefecture_id"
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -98,7 +98,7 @@
               = fa.label "都道府県"
               %span 必須
               .form-group__select-wrap
-                = fa.collection_select :prefecture, Prefecture.all, :id, :name, {}, class: "prefecture-select"
+                = fa.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class: "prefecture-select"
                 %i.fa.fa-chevron-down.chevron-prefecture
                 %ul.error__prefecture
             .form-group

--- a/db/migrate/20190623144532_create_user_details.rb
+++ b/db/migrate/20190623144532_create_user_details.rb
@@ -8,7 +8,7 @@ class CreateUserDetails < ActiveRecord::Migration[5.2]
       t.date :date_of_birth, null: false
       t.string :phone_number, null: false
       t.string :postal_code, null: false
-      t.string :prefecture, null: false
+      t.integer :prefecture_id, null: false, foreign_key: true
       t.string :city, null: false
       t.string :address, null: false
       t.string :building_name

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2019_07_10_143233) do
     t.date "date_of_birth", null: false
     t.string "phone_number", null: false
     t.string "postal_code", null: false
-    t.string "prefecture", null: false
+    t.integer "prefecture_id", null: false
     t.string "city", null: false
     t.string "address", null: false
     t.string "building_name"


### PR DESCRIPTION
## WHAT
user_detailテーブルのprefectureカラムをprefecture_idに変更し、user_detailに紐づいているprefectureを取得できるようにした

## WHY
user_detailからprefecture_idを取得するため
